### PR TITLE
[Feat] 일기 작성 페이지 추가구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@types/styled-components": "^5.1.34",
+        "axios": "^1.7.3",
         "emoji-picker-react": "^4.11.1",
         "framer-motion": "^11.3.19",
         "react": "^18.3.1",
@@ -5200,6 +5201,29 @@
       "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14527,6 +14551,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/styled-components": "^5.1.34",
+    "axios": "^1.7.3",
     "emoji-picker-react": "^4.11.1",
     "framer-motion": "^11.3.19",
     "react": "^18.3.1",

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,0 +1,21 @@
+import axios, { AxiosRequestConfig } from "axios";
+
+const DEFAULT_PORT = process.env.REACT_APP_PORT;
+const BASE_URL = `http://localhost:${DEFAULT_PORT}`;
+const DEFAULT_TIMEOUT = 10000 * 60;
+
+export const createClient = (config?: AxiosRequestConfig) => {
+  const axiosInstance = axios.create({
+    baseURL: BASE_URL,
+    timeout: DEFAULT_TIMEOUT,
+    headers: {
+      "content-type": "application/json"
+    },
+    withCredentials: true,
+    ...config
+  });
+
+  return axiosInstance;
+};
+
+export const httpClient = createClient();

--- a/src/constants/writeDiary.ts
+++ b/src/constants/writeDiary.ts
@@ -1,15 +1,17 @@
+import { theme } from "../styles/theme";
+
 export const colors = [
-  { name: 'default', background: '#FFFFFF' },
-  { name: 'orange', background: '#FF87461A' },
-  { name: 'beige', background: '#FFD2791A' },
-  { name: 'yellow', background: '#FFDD2B1A' },
-  { name: 'green', background: '#8FEC471A' },
-  { name: 'mint', background: '#71F8C81A' },
-  { name: 'blue', background: '#9AD9EA1A' },
-  { name: 'coolblue', background: '#8AA3F91A' },
-  { name: 'purple', background: '#BA84FF1A' },
-  { name: 'pink', background: '#EA9ACA1A' },
-  { name: 'gray', background: '#9999991A' },
+  { name: 'default', background: theme.diaryColor.default.background },
+  { name: 'orange', background: theme.diaryColor.orange.background },
+  { name: 'beige', background: theme.diaryColor.beige.background },
+  { name: 'yellow', background: theme.diaryColor.yellow.background },
+  { name: 'green', background: theme.diaryColor.green.background },
+  { name: 'mint', background: theme.diaryColor.mint.background },
+  { name: 'blue', background: theme.diaryColor.blue.background },
+  { name: 'coolblue', background: theme.diaryColor.coolblue.background },
+  { name: 'purple', background: theme.diaryColor.purple.background },
+  { name: 'pink', background: theme.diaryColor.pink.background },
+  { name: 'gray', background: theme.diaryColor.gray.background },
 ];
 
 export const moods = ["😍", "😆", "🙂", "😟", "😡"];

--- a/src/hooks/useGeoLocation.ts
+++ b/src/hooks/useGeoLocation.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+
+interface ILocation {
+  latitude: number;
+  longitude: number;
+}
+
+export const useGeoLocation = (options = {}) => {
+  const [location, setLocation] = useState<ILocation>();
+  const [error, setError] = useState("");
+
+  const handleSuccess = (pos: GeolocationPosition) => {
+    const { latitude, longitude } = pos.coords;
+
+    setLocation({
+      latitude,
+      longitude,
+    });
+  };
+
+  const handleError = (err: GeolocationPositionError) => {
+    setError(err.message);
+  };
+
+  useEffect(() => {
+    const { geolocation } = navigator;
+
+    if (!geolocation) {
+      setError("Geolocation is not supported.");
+      return;
+    }
+
+    geolocation.getCurrentPosition(handleSuccess, handleError, options);
+  }, [options]);
+
+  return { location, error };
+}

--- a/src/pages/WriteDiary.tsx
+++ b/src/pages/WriteDiary.tsx
@@ -8,26 +8,51 @@ import { useEffect, useRef, useState } from 'react';
 import EmojiPicker from 'emoji-picker-react';
 import DiaryPreview from '../components/diary/DiaryPreview';
 import { colors, moods, privacies } from '../constants/writeDiary';
+import { useGeoLocation } from '../hooks/useGeoLocation';
+
+const geolocationOptions = {
+  enableHighAccuracy: true,
+  timeout: 1000 * 10,
+  maximumAge: 1000 * 3600 * 24,
+}
 
 const WriteDiary = () => {
+  // 날짜, 요일
+  const week = ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"];
+  const today = new Date();
+  const todayDay = week[today.getDay()];
+  const formattedDate = `${today.getFullYear()}년 ${today.getMonth() + 1}월 ${today.getDate()}일 ${todayDay}`;
+
+  // 날씨
+  const { location, error } = useGeoLocation(geolocationOptions);
+  if(location) {
+    console.log("위도 : ", location?.latitude);
+    console.log("경도 : ", location?.longitude);
+  } else {
+    console.log("GeoLocationError : ", error);
+  }
+  
+  // 상태 (오늘의 이모지, 배경 색상, 기분, 공개 범위)
   const [selectedEmoji, setSelectedEmoji] = useState<string>("");
   const [selectedBgColor, setSelectedBgColor] = useState<string>("default");
   const [selectedMood, setSelectedMood] = useState<string>("😍");
   const [selectedPrivacy, setSelectedPrivacy] = useState<string>(privacies[2]);
 
+  // 드롭다운 여부 (오늘의 이모지, 배경 색상, 기분, 공개 범위, 미리보기)
   const [isEmojiDropdown, setIsEmojiDropdown] = useState(false);
   const [isBgColorDropdown, setIsBgColorDropdown] = useState(false);
   const [isMoodDropdown, setIsMoodDropdown] = useState(false);
   const [isPrivacyDropdown, setIsPrivacyDropdown] = useState(false);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
+  // 현재 드롭다운이 되는 영역 (오늘의 이모지, 배경 색상, 기분, 공개 범위, 미리보기)
   const emojiDropdownRef = useRef<HTMLDivElement>(null);
   const bgColorDropdownRef = useRef<HTMLDivElement>(null);
   const moodDropdownRef = useRef<HTMLDivElement>(null);
   const privacyDropdownRef = useRef<HTMLDivElement>(null);
   const previewOpenRef = useRef<HTMLDivElement>(null);
 
-  // toogleDropDown
+  // 드롭다운 토글 함수 (오늘의 이모지, 배경 색상, 기분, 공개 범위)
   const toogleEmojiDropdown = () => {
     setIsEmojiDropdown(!isEmojiDropdown);
   };
@@ -44,7 +69,7 @@ const WriteDiary = () => {
     setIsPreviewOpen(!isPreviewOpen);
   };
 
-  // selectOption
+  // 드롭다운 옵션 (배경 색상, 기분, 공개 범위)
   const selectBgColorOption = (option: string) => {
     setSelectedBgColor(option);
     setIsBgColorDropdown(false);
@@ -58,7 +83,7 @@ const WriteDiary = () => {
     setIsPrivacyDropdown(false);
   };
 
-  // 외부 클릭 시 드롭다운 닫힘
+  // 외부 클릭 시 드롭다운 닫힘 (오늘의 이모지, 배경 색상, 기분, 공개 범위, 미리보기)
   const handleClickEmojiOutside = (e: MouseEvent) => {
     if(emojiDropdownRef.current && !emojiDropdownRef.current.contains(e.target as Node)) {
       setIsEmojiDropdown(false);
@@ -189,7 +214,7 @@ const WriteDiary = () => {
         {/* 오늘의 날짜 */}
         <Section className="today">
           <label>날짜</label>
-          <span>2024년 7월 17일 목요일</span>
+          <span>{formattedDate}</span>
         </Section>
         {/* 오늘의 날씨 */}
         <Section className="weather">

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -13,9 +13,9 @@ export const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
     padding: 0;
-    font-family: ${({ theme }) => theme.fontFamily.en};
     color: ${({ theme }) => theme.color.black};
     background-color: ${({ theme }) => theme.color.white};
+    font-family: ${({ theme }) => theme.fontFamily.en};
   }
 
   a {

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,5 +1,4 @@
 import { createGlobalStyle } from "styled-components";
-import { theme } from "./theme";
 
 export const GlobalStyle = createGlobalStyle`
   @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
@@ -14,7 +13,7 @@ export const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
     padding: 0;
-    font-family: ${theme.fontFamily.en};
+    font-family: ${({ theme }) => theme.fontFamily.en};
     color: ${({ theme }) => theme.color.black};
     background-color: ${({ theme }) => theme.color.white};
   }


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #33 
- 위치 기반 허용 시 해당 위치의 위도, 경도를 가져오는 기능 구현
- http 파일 기본 구현

## ⭐ 작업 상세 설명

- 배경 색상 theme.ts 파일에서 가져오기
(색상을 백엔드에 보내고 받아올 때는 그 색상의 이름을 공유하고, 프론트에서 그 이름에 해당하는 색상을 출력하는 방식)

- http 파일 기본 구현(zustand 이용한 store는 아직 개발 안 된 상태)

- 위도 경도 콘솔에 출력 (원래는 날씨 api로 post 해야함)
![position](https://github.com/user-attachments/assets/bbaee7bf-d02a-48ff-95c0-0cc270c44beb)


## 💬 리뷰 요구사항(선택)

- ex) 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
