### PR TITLE
[Design] 폰트 및 폰트 굵기 변경 #42

### DIFF
--- a/src/components/comment/Comment.tsx
+++ b/src/components/comment/Comment.tsx
@@ -134,12 +134,14 @@ const DefaultProfileIcon = styled(FaUserCircle)`
 `;
 
 const Username = styled.div`
-  font-weight: bold;
+  margin-bottom: 2px;
   font-size: ${({ theme }) => theme.text.text3};
+  font-weight: 500;
 `;
 
 const CommentDate = styled.div`
   color: ${({ theme }) => theme.color.gray999};
+  font-size: ${({ theme }) => theme.text.text3};
 `;
 
 const CommentText = styled.div`

--- a/src/components/diary/Calender.tsx
+++ b/src/components/diary/Calender.tsx
@@ -269,6 +269,7 @@ const Table = styled.table`
   th {
     padding: 10px 0 15px;
     background-color: transparent;
+    font-weight: 400;
   }
 `;
 

--- a/src/components/diary/PlayList.tsx
+++ b/src/components/diary/PlayList.tsx
@@ -115,13 +115,15 @@ const Table = styled.table`
   border-spacing: 0; 
   border: 1px solid ${({ theme }) => theme.color.grayDF}; 
   border-radius: 8px;
-  font-family: ${({ theme }) => theme.fontFamily.kor};
   .playListHeader th {
-    border-bottom: 1px solid ${({ theme }) => theme.color.grayDF}; 
+    border-bottom: 1px solid ${({ theme }) => theme.color.grayDF};
+    font-family: ${({ theme }) => theme.fontFamily.kor};
   }
   th, td {
-    padding: 10px;
+    padding: 12px 10px;
     border: none;
+    font-family: ${({ theme }) => theme.fontFamily.kor};
+    font-size: 14px;
   }
 `;
 

--- a/src/components/header/BeforeLoginHeader.tsx
+++ b/src/components/header/BeforeLoginHeader.tsx
@@ -52,7 +52,7 @@ const Logo = styled.div`
     background-clip: text;
     color: transparent;
     font-size: ${({ theme }) => theme.title.title3};
-    font-weight: bold;
+    font-weight: 600;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
   }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -156,7 +156,7 @@ const Logo = styled.div`
   h1 {
     margin-left: 10px;
     font-size: ${({ theme }) => theme.title.title3};
-    font-weight: bold;
+    font-weight: 600;
     background: linear-gradient(90deg, #9ad9ea, #202879);
     background-clip: text;
     -webkit-background-clip: text;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -51,7 +51,8 @@ const MainLayout = styled.div`
   justify-content: flex-start;
   /* align-items: flex-start; */
   width: 100%;
-  height: calc(100vh - 64px);
+  /* height: calc(100vh - 64px); */
+  height: 100%;
 
   main {
     width: 100%;

--- a/src/components/musicbar/MusicBar.tsx
+++ b/src/components/musicbar/MusicBar.tsx
@@ -259,7 +259,7 @@ const TrackText = styled.div`
 
 const TrackTitle = styled.div`
   font-size: ${({ theme }) => theme.text.text1};
-  font-weight: bold;
+  font-weight: 600;
   color: ${({ theme }) => theme.color.black};
 `;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,8 @@ const createOAuthUrl = (type: AuthType, action: ActionType): string => {
     kakao: 'YOUR_KAKAO_CLIENT_ID'
   };
 
-  const redirect_uri = 'https://melo-diary.vercel.app/auth';
+  const redirect_uri = 'localhost';
+  // const redirect_uri = 'https://melo-diary.vercel.app/auth';
   //const redirect_uri = `https://melo-diary.vercel.app/auth?type=google`;
   const state = JSON.stringify({ type, action });
   

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -16,7 +16,7 @@ interface AuthProviderProps {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(true);
   const [userId, setUserId] = useState<number | null>(null);
 
   useEffect(() => {

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -55,7 +55,7 @@ const LandingContainer = styled.main`
   h1 {
     margin-bottom: 20px;
     font-size: 64px;
-    font-weight: 650;
+    font-weight: 600;
   }
   p {
     margin-bottom: 1em;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -203,14 +203,13 @@ const InfoBox = styled.div`
       font-family: ${({ theme }) => theme.fontFamily.kor};
       
       .name {
-        
         font-size: ${({ theme }) => theme.title.title4};
         font-weight: 400;
       }
       
       .num {
         font-size: ${({ theme }) => theme.title.title3};
-        font-weight: 600;
+        font-weight: 500;
       }
     }
   }
@@ -265,7 +264,7 @@ const FeedItem = styled.li<{ isActive: boolean }>`
   gap: 4px;
   padding: 8px 16px;
   color: ${({ theme, isActive }) => isActive ? theme.color.greenblue : theme.color.grayblack};
-  font-weight: 600;
+  font-weight: 400;
   border-radius: 8px;
   transition: all 0.15s ease-in-out;
   cursor: pointer;

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,13 +1,13 @@
 import { createGlobalStyle } from "styled-components";
 
 export const GlobalStyle = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Nanum+Gothic&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&family=Poppins:wght@100;200;300;400;500;600;700;800&display=swap');
 
   * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    font-family: ${({ theme }) => theme.fontFamily.en};
   }
   
   body {
@@ -15,7 +15,6 @@ export const GlobalStyle = createGlobalStyle`
     padding: 0;
     color: ${({ theme }) => theme.color.black};
     background-color: ${({ theme }) => theme.color.white};
-    font-family: ${({ theme }) => theme.fontFamily.en};
   }
 
   a {


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #42 
- 전체적인 폰트 굵기 재설정

## ⭐ 작업 상세 설명

### 참고사항
- 앞으로 굵기를 설정할 때 숫자로 지정하는 건 어떤가요? 구글 폰트에서 가져온 굵기들을 확인해보았는데, 아래를 확인해주세요!
```tsx
@import url('https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&family=Poppins:wght@100;200;300;400;500;600;700;800&display=swap');
```

`fontSize.en(Poppins - 100, 200, 300, 400, 500, 600, 700, 800)`

`fontSize.kor(Nanum Gothic - 400, 700, 800)`

이렇게가 최대로 가져올 수 있는 굵기더라구요! 특히 영어 폰트는 굵기가 매우 다양하니 더 수월하게 선택하실 수 있을 것 같아요 ㅎㅎㅎ

### 작업 환경 임시 설정
- config.ts → `redirect_uri` 를 localhost 로 변경하여 작업 중이여서 그렇게 올라갔을거에요!
- AuthContext.tsx → `isAuthenticated` 상태를 `true`로 바꿔서 작업 중이였습니다!! 
혹시 헷갈리실까봐 변경한 모든 부분 작성해둡니다 ㅎㅎ

### 변경 사항
- Layout.tsx
    - `height: calc(100vh - 64px);` 으로 할 시 일기 작성 페이지에서 배경 색상을 적용했을 때 아래가 잘리는 현상이 발생합니다. 따라서 임시로 높이값을 `100%`로 바꿔놓았습니다!
    - 페이지별로 높이값이 다 다른데, 혹시 `height: calc(100vh - 64px);` 가 적용되어야 하는 페이지는 해당 컴포넌트 Wrapper 높이에 적용하는 건 어떠신가요?? 👻
- Comment.tsx
    - 프로필 사진과 닉네임 수평이 아주 약간 안맞는 것 같아서 `margin-bottom: 2px;` 을 주었습니다. 혹시 보시기에 어색하다면 추후에 다시 삭제해주셔도 됩니다!
    - 댓글 오른쪽에 있는 날짜 폰트 크기가 생각보다 커서 크기를 줄였습니다.
- Calendar.tsx
    - 달력의 요일(영어) 굵기를 400으로 부여하였습니다.
- Playlist.tsx
    - 폰트를 한글 폰트로 바꾸었는데, 그랬더니 행 간격이 많이 줄어들어서 상하 패딩을 `12px`로 추가하였습니다.
        ![image](https://github.com/user-attachments/assets/8b2fca5b-0bfb-4fb3-b454-9c08c85dc73e)
- Landing.tsx, BeforeLoginHeader.tsx, Header.tsx, MusicBar.tsx,
    - 랜딩페이지 메세지(h1), 헤더 로고, 뮤직바 제목 굵기를 bold 대신 600으로 변경하였습니다.
    (`bold`보다 600이 더 얇더라구요 ㅎㅎ)
- MyPage.tsx
    - 숫자, 탭 굵기 변경

## 💬 리뷰 요구사항(선택)

- 버그를 하나 발견했는데,, 그 일기페이지가 fixed로 고정되어있어서 그런지 일기 화면을 위아래로 움직일 때 틀 밖으로 삐져나오는(?) 현상이 있어요! 근데 이게 제가 수정 후에 생긴 버그인지 아닌지,, 헷갈리네요😵
![overflow-bug](https://github.com/user-attachments/assets/c4cd65b4-9a8f-4454-b31d-ea9f2571ce97)

