### PR TITLE
[Feat] 닉네임 설정 페이지 #36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.7.3",
         "emoji-picker-react": "^4.11.1",
         "framer-motion": "^11.3.19",
+        "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.2.1",
@@ -27,7 +28,8 @@
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.12",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.5.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -12175,6 +12177,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -17373,6 +17383,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18376,6 +18394,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
+      "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.7.3",
     "emoji-picker-react": "^4.11.1",
     "framer-motion": "^11.3.19",
+    "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",
@@ -22,7 +23,8 @@
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.12",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.5.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
-import { ISignup } from '../models/user.model';
+import { INicknameRequest, ISignup } from '../models/user.model';
+import { useUserStore } from '../store/authStore';
 const port = process.env.REACT_APP_PORT || '3000';
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
@@ -8,6 +9,7 @@ export const handleGoogleOAuthURL = async (code: string): Promise<{ access_token
   return response.data;
 };
 
+//회원가입
 export const signUp = async (data: ISignup): Promise<AxiosResponse<{ access_token: string; user_id: any }>> => {
   let response;
   response = await axios.post(`${API_BASE_URL}/users`, data, {
@@ -17,10 +19,29 @@ export const signUp = async (data: ISignup): Promise<AxiosResponse<{ access_toke
   
 };
 
+//로그인
 export const login = async (data: ISignup): Promise<AxiosResponse<{ access_token: string; user_id: any }>>  => {
   let response;
   response = await axios.post(`${API_BASE_URL}/users/login`, data, {
     withCredentials: true,
   });
+  return response;
+};
+
+//최초 닉네임 등록
+export const registerNickname = async (id: string, nickname: string): Promise<AxiosResponse<any>> => {
+  const accessToken = localStorage.getItem('access_token');
+  const userId = parseInt(id, 10)
+  const data: INicknameRequest = {
+    nickname,
+  };
+
+  const response = await axios.post(`${API_BASE_URL}/users/${userId}/nickname`, data, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`, // Authorization 헤더에 Bearer 토큰 포함
+    },
+    withCredentials: true,
+  });
+
   return response;
 };

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,34 +1,26 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { ISignup } from '../models/user.model';
 const port = process.env.REACT_APP_PORT || '3000';
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
-export const handleGoogleOAuthURL = async (code: string): Promise<{ token: string, user: any }> => {
+export const handleGoogleOAuthURL = async (code: string): Promise<{ access_token: string, user_id: any }> => {
   const response = await axios.post(`${API_BASE_URL}/auth/oauth/google`, { code });
   return response.data;
 };
 
-export const signUp = async (data: ISignup) => {
-  try {
-    await axios.post('https://api.melodiary.site/api/users', data, {
-      withCredentials: true
-      })
-      .then((response: { data: any }) => {
-        return response;
-      })
-      .catch((error: any) => {
-        console.error('Error:', error);
-      });
-  } catch (error) {
-    console.error("회원가입에 실패했습니다.", error);
-  }
+export const signUp = async (data: ISignup): Promise<AxiosResponse<{ access_token: string; user_id: any }>> => {
+  let response;
+  response = await axios.post(`${API_BASE_URL}/users`, data, {
+    withCredentials: true,
+  });
+  return response;
+  
 };
 
-export const login = async (data: ISignup)  => {
-  try {
-    const response = await axios.post(`${API_BASE_URL}/users/login`, data);
-    return response.data;
-  } catch (error) {
-    console.error("로그인에 실패했습니다.", error);
-  }
+export const login = async (data: ISignup): Promise<AxiosResponse<{ access_token: string; user_id: any }>>  => {
+  let response;
+  response = await axios.post(`${API_BASE_URL}/users/login`, data, {
+    withCredentials: true,
+  });
+  return response;
 };

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,13 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 import { INicknameRequest, ISignup } from '../models/user.model';
-import { useUserStore } from '../store/authStore';
-const port = process.env.REACT_APP_PORT || '3000';
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
-
-export const handleGoogleOAuthURL = async (code: string): Promise<{ access_token: string, user_id: any }> => {
-  const response = await axios.post(`${API_BASE_URL}/auth/oauth/google`, { code });
-  return response.data;
-};
 
 //회원가입
 export const signUp = async (data: ISignup): Promise<AxiosResponse<{ access_token: string; user_id: any }>> => {

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -14,8 +14,7 @@ export const signUp = async (data: ISignup) => {
       withCredentials: true
       })
       .then((response: { data: any }) => {
-        //console.log('Successfully received jwt:', response.data);
-        return response.data;
+        return response;
       })
       .catch((error: any) => {
         console.error('Error:', error);

--- a/src/components/header/BeforeLoginHeader.tsx
+++ b/src/components/header/BeforeLoginHeader.tsx
@@ -4,7 +4,21 @@ import { FiGithub } from "react-icons/fi";
 import { BiHeadphone } from "react-icons/bi";
 import { Link } from 'react-router-dom';
 
-const LandingHeader = () => {
+interface BeforeLoginHeaderProps {
+  isNicknamePage?: boolean;
+}
+
+const LandingHeader: React.FC<BeforeLoginHeaderProps> = ({ isNicknamePage }) => {
+  if (isNicknamePage) {
+    return(
+      <HeaderContainer>
+          <Logo>
+            <BiHeadphone size={24} />
+            <h1>MeloDiary </h1> 
+          </Logo>
+      </HeaderContainer>
+    );
+  }
   return(
     <HeaderContainer>
       <Link to="/">

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -4,13 +4,18 @@ import Sidebar from '../sidebar/Sidebar';
 import { useState } from 'react';
 import BeforeLoginHeader from '../header/BeforeLoginHeader';
 import { useAuth } from '../../context/AuthContext';
+import { useLocation } from 'react-router-dom';
 
 interface Props {
   children: React.ReactNode;
 }
 
 const Layout = ({ children }: Props) => {
-  const {isAuthenticated, logout} = useAuth();
+  const {isAuthenticated} = useAuth();
+  const location = useLocation();
+  
+  // 닉네임 페이지 경로 확인
+  const isNicknamePage = location.pathname === '/nickname'
 
   return (
     <LayoutWrapper>
@@ -26,7 +31,7 @@ const Layout = ({ children }: Props) => {
         </>
       ) : (
         <>
-        <BeforeLoginHeader />
+        <BeforeLoginHeader isNicknamePage={isNicknamePage} />
         <main>
           {children}
         </main>

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,7 @@ const createOAuthUrl = (type: AuthType, action: ActionType): string => {
     kakao: 'YOUR_KAKAO_CLIENT_ID'
   };
 
-  const redirect_uri = 'https://melo-diary.vercel.app/auth';
-  //const redirect_uri = `https://melo-diary.vercel.app/auth?type=google`;
+  const redirect_uri = 'https://melodiary.site/auth';
   const state = JSON.stringify({ type, action });
   
   let auth_url = '';
@@ -30,6 +29,3 @@ export const KAKAO_LOGIN_URL = createOAuthUrl('kakao', 'login');
 export const GOOGLE_LOGIN_URL = createOAuthUrl('google', 'login');
 //네이버 state 추후 수정 Math.random().toString(36).substr(2, 11)
 export const NAVER_LOGIN_URL = createOAuthUrl('naver', 'login');
-
-export const GOOGLE_REDIRECT_URI = `https://melo-diary.vercel.app/auth?type=google`;
-export const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=email`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,11 @@
 type AuthType = 'google' | 'naver' | 'kakao';
 type ActionType = 'signup' | 'login';
 
+const GOOGLE_CLIENT_ID = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+
 const createOAuthUrl = (type: AuthType, action: ActionType): string => {
   const client_ids = {
-    google: '137081432785-0rhjqb5shd67ov2ec4escraufk5fd6kt.apps.googleusercontent.com',
+    google: GOOGLE_CLIENT_ID,
     naver: 'YOUR_NAVER_CLIENT_ID',
     kakao: 'YOUR_KAKAO_CLIENT_ID'
   };

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,12 +1,10 @@
 // AuthContext.tsx
 import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 interface AuthContextType {
   isAuthenticated: boolean;
-  login: (accessToken: string, userId: number) => void;
+  login: (accessToken: string) => void;
   logout: () => void;
-  userId: number | null;
 }
 
 interface AuthProviderProps {
@@ -17,34 +15,27 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-  const [userId, setUserId] = useState<number | null>(null);
 
   useEffect(() => {
     const accessToken = localStorage.getItem('accessToken');
-    const userId = localStorage.getItem('userId');
 
-    if (accessToken && userId) {
+    if (accessToken) {
       setIsAuthenticated(true);
-      setUserId(Number(userId));
     }
   }, []);
 
-  const login = (accessToken: string, userId: number) => {
+  const login = (accessToken: string) => {
     localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('userId', userId.toString());
     setIsAuthenticated(true);
-    setUserId(userId);
   };
 
   const logout = () => {
     localStorage.removeItem('accessToken');
-    localStorage.removeItem('userId');
     setIsAuthenticated(false);
-    setUserId(null);
   };
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, login, logout, userId }}>
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useState, useContext, useEffect, ReactNode } from
 
 interface AuthContextType {
   isAuthenticated: boolean;
-  login: (accessToken: string) => void;
+  login: (access_token: string, user_id: number) => void;
   logout: () => void;
 }
 
@@ -17,20 +17,23 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
 
   useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
+    const access_token = localStorage.getItem('access_token');
+    const user_id = localStorage.getItem('user_id');
 
-    if (accessToken) {
+    if (access_token) {
       setIsAuthenticated(true);
     }
   }, []);
 
-  const login = (accessToken: string) => {
-    localStorage.setItem('accessToken', accessToken);
+  const login = (access_token: string, user_id: number) => {
+    localStorage.setItem('access_token', access_token);
+    localStorage.setItem('user_id', user_id.toString());
     setIsAuthenticated(true);
   };
 
   const logout = () => {
-    localStorage.removeItem('accessToken');
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('user_id');
     setIsAuthenticated(false);
   };
 
@@ -49,15 +52,15 @@ export const useAuth = (): AuthContextType => {
   return context;
 };
 
-// 추가: loader 함수 정의 및 내보내기
-export const tokenLoader = async () => {
-  const accessToken = localStorage.getItem('accessToken');
-  const userId = localStorage.getItem('userId');
 
-  if (accessToken && userId) {
+export const tokenLoader = async () => {
+  const access_token = localStorage.getItem('access_token');
+  const user_id = localStorage.getItem('user_id');
+
+  if (access_token) {
     return {
       isAuthenticated: true,
-      userId: Number(userId),
+      userId: Number(user_id),
     };
   } else {
     return {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,8 +3,11 @@ import React, { createContext, useState, useContext, useEffect, ReactNode } from
 
 interface AuthContextType {
   isAuthenticated: boolean;
+  isSignupComplete: boolean;
   login: (access_token: string, user_id: number) => void;
   logout: () => void;
+  completeSignup: () => void;
+  setIsSignupComplete: (value: boolean) => void;
 }
 
 interface AuthProviderProps {
@@ -15,6 +18,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const [isSignupComplete, setIsSignupComplete] = useState<boolean>(false);
 
   useEffect(() => {
     const access_token = localStorage.getItem('access_token');
@@ -37,8 +41,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     setIsAuthenticated(false);
   };
 
+  const completeSignup = () => {
+    setIsSignupComplete(true);
+  };
+
   return (
-    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+    <AuthContext.Provider value={{ isAuthenticated, isSignupComplete, login, completeSignup, logout, setIsSignupComplete}}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -60,7 +60,6 @@ export const useAuth = (): AuthContextType => {
   return context;
 };
 
-
 export const tokenLoader = async () => {
   const access_token = localStorage.getItem('access_token');
   const user_id = localStorage.getItem('user_id');

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -3,3 +3,6 @@ export interface ISignup {
     authorization_code : string,
 }
 
+export interface INicknameRequest {
+    nickname: string;
+}

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -2,3 +2,4 @@ export interface ISignup {
     service_provider : string,
     authorization_code : string,
 }
+

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -64,12 +64,11 @@ const Auth = () => {
         }
       } else {
         console.error('Missing required parameters: code or state');
-        //navigate('/login'); 
       }
     };
 
     handleOAuth();
-  }, [navigate, stateParam, code, setUserId, setAuthToken]);
+  }, [navigate, stateParam, code, setUserId, setAuthToken, completeSignup]);
   
   const closeModal = () => {
     setModalMessage(null);
@@ -128,6 +127,7 @@ const JoinWrapper = styled.div`
   background-position: center;
   background-attachment: fixed;   
 `;
+
 const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -136,6 +136,7 @@ const ContentWrapper = styled.div`
   height:92vh;
   padding-left: 5%;
 `;
+
 const JoinTitle = styled.h1`
   margin-bottom: 0.5rem;    
   font-size: 2rem;
@@ -180,12 +181,13 @@ const Button = styled.button`
   }
   &.naver {
     background-color: #03c75a;
-    color: #fff;
+    color: ${({ theme }) => theme.color.white};
   }
   &.naver:hover {
     background-color: #02b04a;
   }
 `;
+
 const IconWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -196,9 +198,9 @@ const IconWrapper = styled.div`
 const LoginLink = styled.div`
   margin-top: 0.5rem;
   font-size: 0.9rem;
-  color: #555;
+  color: ${({ theme }) => theme.color.gray777};
   .loginBtn{
-    color: #555;
+    color: ${({ theme }) => theme.color.gray777};
     text-decoration: underline;
   }
 `;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -4,7 +4,7 @@ import { FcGoogle } from "react-icons/fc";
 import { SiNaver } from "react-icons/si";
 import { RiKakaoTalkFill } from "react-icons/ri";
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { ISignup } from '../models/user.model';
 import { signUp, login } from '../api/auth.api';
 import axios from 'axios';
@@ -33,22 +33,18 @@ const Auth = () => {
         try {
           let response;
           if (action === 'signup') {
-            response = await axios.post('https://api.melodiary.site/api/users', authData, {
-              withCredentials: true,
-            });
+            response = await signUp(authData);
           } else if (action === 'login') {
-            response = await axios.post('https://api.melodiary.site/api/users/login', authData, {
-              withCredentials: true,
-            });
+            response = await login(authData);
           }
+
           if (response) {
             console.log('Successfully received jwt:', response.data);
-            const { accessToken, userId } = response.data;
+            const { accessToken } = response.data;
             localStorage.setItem('accessToken', accessToken);
-            localStorage.setItem('userId', userId);
-            setAuthToken(accessToken, userId);
+            setAuthToken(accessToken);
             if(action === 'signup'){
-              //navigate('/nickname'); // 리다이렉트
+              navigate('/nickname'); // 리다이렉트
             } else if (action === 'login') {
               navigate('/home'); 
             }  
@@ -96,6 +92,7 @@ const Auth = () => {
               <IconWrapper><SiNaver/></IconWrapper>
               Naver로 시작하기
             </Button>
+            <LoginLink >이미 계정이 있으신가요? <Link to='/login' className='loginBtn'>로그인</Link></LoginLink>
         </ButtonContainer>
       </ContentWrapper>
       {modalMessage && (
@@ -180,6 +177,16 @@ const IconWrapper = styled.div`
   align-items: center;
   justify-content: center;
   margin-right: 50px;
+`;
+
+const LoginLink = styled.div`
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+  .loginBtn{
+    color: #555;
+    text-decoration: underline;
+  }
 `;
 
 export default Auth ;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -14,7 +14,7 @@ import { useUserStore } from '../store/authStore';
 
 const Auth = () => {
   const navigate = useNavigate();
-  const { login: setAuthToken } = useAuth();
+  const { login: setAuthToken, completeSignup } = useAuth();
   const urlParams = new URLSearchParams(window.location.search);
   const stateParam = urlParams.get('state');
   const code = urlParams.get('code');
@@ -46,7 +46,7 @@ const Auth = () => {
             localStorage.setItem('access_token', access_token);
             localStorage.setItem('user_id', user_id.toString());
             if(action === 'signup'){
-              localStorage.setItem('access_token', access_token);
+              completeSignup();
               navigate(`/nickname`); // 리다이렉트
             } else if (action === 'login') {
               setAuthToken(access_token, user_id);

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -32,17 +32,17 @@ const Auth = () => {
 
         try {
           let response;
-          if (action === 'signup') {
+           if (action === 'signup') {
             response = await signUp(authData);
           } else if (action === 'login') {
-            response = await login(authData);
+            response = await login(authData); 
           }
 
           if (response) {
             console.log('Successfully received jwt:', response.data);
-            const { accessToken } = response.data;
-            localStorage.setItem('accessToken', accessToken);
-            setAuthToken(accessToken);
+            const { access_token } = response.data;
+            localStorage.setItem('access_token', access_token);
+            setAuthToken(access_token);
             if(action === 'signup'){
               navigate('/nickname'); // 리다이렉트
             } else if (action === 'login') {
@@ -50,8 +50,10 @@ const Auth = () => {
             }  
           }
         } catch (error) {
-          if (axios.isAxiosError(error) && error.response?.status === 409) {
+          if (axios.isAxiosError(error) && error.response?.status === 409 && action === 'signup') {
             setModalMessage("이미 가입된 정보가 있습니다. \n로그인 화면으로 이동할까요?");
+          } else if (axios.isAxiosError(error) && error.response?.status === 404 && action === 'login') {
+            setModalMessage("없는 계정입니다. \n회원가입 화면으로 이동할까요?");
           } else {
             console.error('OAuth 실패:', error);
           }
@@ -67,12 +69,20 @@ const Auth = () => {
   
   const closeModal = () => {
     setModalMessage(null);
-    navigate('/join');
+    if(action === 'signup'){
+      navigate('/join');
+    }else if(action === 'login') {
+      navigate('/login');
+    }
   };
 
   const confirmModal = () => {
     setModalMessage(null);
-    navigate('/login');
+    if(action === 'signup'){
+      navigate('/login');
+    }else if(action === 'login') {
+      navigate('/join');
+    }
   };
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import MusicBar from "../components/musicbar/MusicBar";
 import Calendar from "../components/diary/Calender";
 import PlayList from "../components/diary/PlayList";
 import { dummyDiaries, dummyLikedUsers, dummyUsers } from "../dummyData";
+import { useUserStore } from "../store/authStore";
 
 const Home = () => {
   const { isAuthenticated } = useAuth();

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -105,7 +105,7 @@ const Button = styled.button`
   }
   &.naver {
     background-color: #03c75a;
-    color: #fff;
+    color: ${({ theme }) => theme.color.white};
   }
   &.naver:hover {
     background-color: #02b04a;
@@ -122,9 +122,9 @@ const IconWrapper = styled.div`
 const LoginLink = styled.div`
   margin-top: 0.5rem;
   font-size: 0.9rem;
-  color: #555;
+  color: ${({ theme }) => theme.color.gray777};
   .loginBtn{
-    color: #555;
+    color: ${({ theme }) => theme.color.gray777};
     text-decoration: underline;
   }
 `;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -105,7 +105,7 @@ const Button = styled.button`
   }
   &.naver {
     background-color: #03c75a;
-    color: #fff;
+    color: ${({ theme }) => theme.color.white};
   }
   &.naver:hover {
     background-color: #02b04a;
@@ -122,9 +122,9 @@ const IconWrapper = styled.div`
 const LoginLink = styled.div`
   margin-top: 0.5rem;
   font-size: 0.9rem;
-  color: #555;
+  color: ${({ theme }) => theme.color.gray777};
   .loginBtn{
-    color: #555;
+    color: ${({ theme }) => theme.color.gray777};
     text-decoration: underline;
   }
 `;

--- a/src/pages/Nickname.tsx
+++ b/src/pages/Nickname.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { BiHeadphone } from "react-icons/bi";
-import { useUserStore } from '../store/authStore';
 import { registerNickname } from '../api/auth.api';
 import axios from 'axios';
 import { useAuth } from '../context/AuthContext';
@@ -15,11 +14,9 @@ const NickName = () => {
   const { isSignupComplete, setIsSignupComplete } = useAuth();
 
   useEffect(() => {
-    console.log(isSignupComplete);
     if (!isSignupComplete) {
       navigate('/'); // 접근을 막고 싶은 페이지로 리다이렉트
     }
-
     // 컴포넌트가 언마운트될 때 상태 초기화
     return () => {
       setIsSignupComplete(false);
@@ -44,8 +41,6 @@ const NickName = () => {
         console.log('닉네임 등록 성공:', response.data);
         setAuthToken(accessToken, Number(userId));
         navigate('/home'); // 닉네임 등록 후 홈으로 이동
-        
-        // 추가적인 로직이 필요하면 여기에 작성
       } 
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 409) {
@@ -93,7 +88,7 @@ const ContentWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 20px;
-  background-color: white;
+  background-color: ${({ theme }) => theme.color.white};
   border-radius: 10px;
 `;
 
@@ -101,7 +96,7 @@ const Logo = styled.div`
   display: flex;
   align-items: center;
   margin-bottom: 5px;
-  font-family: ${({theme}) => theme.fontFamily.kor};
+  font-family: ${({ theme }) => theme.fontFamily.kor};
   svg {
     color: ${({ theme }) => theme.color.gray999};
   }
@@ -110,7 +105,7 @@ const Logo = styled.div`
     background: linear-gradient(90deg, #9ad9ea, #202879);
     background-clip: text;
     color: transparent;
-    font-family: ${({theme}) => theme.fontFamily.eng};
+    font-family: ${({ theme }) => theme.fontFamily.eng};
     font-size: ${({ theme }) => theme.title.title3};
     font-weight: bold;
     -webkit-background-clip: text;
@@ -122,8 +117,8 @@ const WelcomeMessage = styled.p`
   margin-bottom: 20px;
   text-align: center;  
   font-size: 1rem;
-  color: #333;
-  font-family: ${({theme}) => theme.fontFamily.kor};
+  color: ${({ theme }) => theme.color.grayblack};
+  font-family: ${({ theme }) => theme.fontFamily.kor};
 `;
 
 const InputWrapper = styled.div`
@@ -136,18 +131,18 @@ const NicknameInput = styled.input<{ isError: boolean }>`
   width: 100%;
   padding: 10px;
   margin-bottom: 5px;
-  border: 1px solid ${({ isError, theme }) => isError ? '#fb122f' : '#ddd'};
+  border: 1px solid ${({ isError, theme }) => isError ? '#fb122f' : theme.color.grayDF};
   border-radius: 5px;
   font-size: 1rem;
-  font-family: ${({theme}) => theme.fontFamily.kor};
+  font-family: ${({ theme }) => theme.fontFamily.kor};
   text-align: center;
 `;
 
 const InputInfo = styled.p<{ isError: boolean }>`
   font-size: 0.8rem;
-  color: ${({ isError, theme }) => isError ? '#fb122f': '#888'};
+  color: ${({ isError, theme }) => isError ? '#fb122f': theme.color.gray777};
   text-align: center;
-  font-family: ${({theme}) => theme.fontFamily.kor};
+  font-family: ${({ theme }) => theme.fontFamily.kor};
 `;
 
 const EnterButton = styled.button`
@@ -159,7 +154,7 @@ const EnterButton = styled.button`
   font-size: 1rem;
   color: ${({ theme }) => theme.color.primary};
   cursor: pointer;
-  font-family: ${({theme}) => theme.fontFamily.kor};
+  font-family: ${({ theme }) => theme.fontFamily.kor};
   &:hover {
     color: ${({ theme }) => theme.color.white};
     background-color: ${({ theme }) => theme.color.primary};

--- a/src/pages/Nickname.tsx
+++ b/src/pages/Nickname.tsx
@@ -12,6 +12,20 @@ const NickName = () => {
   const { login: setAuthToken } = useAuth();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const navigate = useNavigate();
+  const { isSignupComplete, setIsSignupComplete } = useAuth();
+
+  useEffect(() => {
+    console.log(isSignupComplete);
+    if (!isSignupComplete) {
+      navigate('/'); // 접근을 막고 싶은 페이지로 리다이렉트
+    }
+
+    // 컴포넌트가 언마운트될 때 상태 초기화
+    return () => {
+      setIsSignupComplete(false);
+    };
+  }, [isSignupComplete, navigate, setIsSignupComplete]);
+
   const handleNicknameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setNickname(event.target.value);
     setErrorMessage(null);

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,14 @@
+import create from 'zustand';
+
+interface UserState {
+    userId: number | null;
+    setUserId: (id: number) => void;
+  }
+  
+  export const useUserStore = create<UserState>((set) => ({
+    userId: null,
+    setUserId: (id: number) => {
+        console.log("Setting userId to:", id);
+        set({ userId: id });
+      },
+  }));


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #36 
### 작업 목록
- [x] 회원가입 후 닉네임 설정 페이지로 리다이렉션
- [x] 닉네임 중복체크 및 API 연결
- [x] 닉네임 설정 완료 후 홈 화면으로 이동
- [x] 회원가입 후를 제외한 모든 사용자는 닉네임 페이지 접근 x

## ⭐ 작업 상세 설명

### 1. 헤더 UI 변경
![image](https://github.com/user-attachments/assets/ccad8e7c-aaf2-48dc-a3af-d63fa82297d3)
- 기존의 Layout 구조에서 닉네임 설정 페이지는 해당되는 곳이 없기에,
```Layout.tsx```에서 닉네임 설정 페이지 여부를 받아와 ```BeforeLoginHeader``` 컴포넌트에 넘기도록 수정했습니다.
### 2. 닉네임 중복체크
![ReactApp-Chrome2024-08-1315-35-58-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2679abbe-d3c3-4ada-97c2-3c10cf873aec)
- 입장하기를 눌렀을 때 중복되는 닉네임의 경우 $${\color{red} 이미\space존재하는\space닉네임입니다}$$.라는 문구가 뜨도록 작성했습니다.
### 3. 닉네임 설정 완료
![ReactApp-Chrome2024-08-1315-35-58-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/d9b7d011-5d92-49da-a65d-77f9da78bdcf)
- 닉네임 설정 완료 후 홈 화면으로 이동합니다.

### 4. Local storage에 response 값 저장
![image](https://github.com/user-attachments/assets/56928617-b05d-4daf-822f-f6ebde20d710)
- 로그인 후 응답으로 오는 user_id와 access_token을 위와 같은 방식으로 저장하도록 수정했습니다.

### 5. 접근 제한 기능 추가
- 회원가입 후 최초 닉네임 설정의 경우만 페이지에 접근할 수 있도록 ```AuthContext.tsx```에 관련 함수를 추가했습니다.

## 추후 수정 및 개발 사항
- http 파일이 추가되면 그에 맞춰 api 연결 코드를 수정할 계획입니다.

## 💬 리뷰 요구사항(선택)

- 닉네임 설정 화면에서 뒤로가기, 새로고침 등을 사용자가 누를 경우 
  **현재 페이지를 벗어날 경우 임의의 닉네임이 설정됩니다.** 라는 알림을 띄울 것인지 고민입니다.
