### PR TITLE
[Feat] 사용자 정보 조회 및 전체 일기 조회 api 연동 #58

### DIFF
--- a/src/api/mypage.api.ts
+++ b/src/api/mypage.api.ts
@@ -1,9 +1,18 @@
 import { httpClient } from "./http";
-import { IDiary } from "../models/mypage.model";
+import { IDiary } from "../models/diary.model";
+import { IUserProfile } from "../models/mypage.model";
 
-export const fetchMyDiaries = async () => {
-  const response = await httpClient.get<IDiary[]>("/api/diaries/myposts");
+// 사용자 정보 조회 api
+export const fetchUserProfile = async (userId: number) => {
+  const response = await httpClient.get<IUserProfile>(`/api/users/${userId}`);
   console.log(response.data);
+
+  return response.data;
+};
+
+// 전체 일기 조회 api
+export const fetchAllDiaries = async () => {
+  const response = await httpClient.get<IDiary[]>("/api/diaries/myposts");
 
   return response.data;
 };

--- a/src/components/mypage/AllDiaries.tsx
+++ b/src/components/mypage/AllDiaries.tsx
@@ -1,13 +1,39 @@
 import styled from 'styled-components';
+import DiaryCard from './DiaryCard';
+import { useMyPage } from '../../hooks/useMyPage';
 
 const AllDiaries = () => {
+  const { userDiaries } = useMyPage();
+
+  if (!userDiaries || userDiaries.length === 0) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <AllDiariesWrapper>
-      <h1>AllDiaries</h1>
+      <DiaryBox>
+        {userDiaries.map((diary) => (
+          <DiaryCard
+            key={diary.id}
+            id={diary.id}
+            created_at={diary.created_at}
+            body={diary.body}
+          />
+        ))}
+      </DiaryBox>
     </AllDiariesWrapper>
-  )
+  );
 };
 
-const AllDiariesWrapper = styled.div``;
-
 export default AllDiaries;
+
+const AllDiariesWrapper = styled.div`
+  width: 1014px;
+`;
+
+const DiaryBox = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  width: 100%;
+`;

--- a/src/components/mypage/DiaryCard.tsx
+++ b/src/components/mypage/DiaryCard.tsx
@@ -1,0 +1,107 @@
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { IDiary } from '../../models/diary.model';
+
+type DiaryCardProps = Pick<IDiary, 'id' | 'created_at' | 'body'>;
+
+const DiaryCard = ({
+  id,
+  created_at,
+  body,
+}: DiaryCardProps) => {
+  const navigate = useNavigate();
+
+  const handleDiaryClick = () => {
+    navigate(`/diary/${id}`);
+  };
+
+  const handleFormatDate = (created_at: string) => {
+    const date = new Date(created_at);
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      weekday: 'long',
+    };
+    return new Intl.DateTimeFormat('ko-KR', options).format(date);
+  };
+
+  const handleScriptHtml = (htmlContent: string) => {
+    const div = document.createElement("div.content");
+    div.innerHTML = htmlContent;
+    return div.innerText;
+  };
+
+  return (
+    <DiaryCardWrapper
+      bgColor={body.background_color ?? "default"}
+      onClick={handleDiaryClick}
+    >
+      <DiaryDate>{handleFormatDate(created_at ?? "")}</DiaryDate>
+      <DiaryTitle>{body.title}</DiaryTitle>
+      <DiaryTagBox bgColor={body.background_color ?? "default"}>
+        <div className="weather">날씨 | {body.weather?.avg_temperature} °C</div>
+        <div className="mood">기분 | {body.emoji}</div>
+        <div className="emoji">오늘의 이모지 | {body.mood}</div>
+      </DiaryTagBox>
+      <DiaryContent>{handleScriptHtml(body.content)}</DiaryContent>
+    </DiaryCardWrapper>
+  );
+};
+
+const DiaryCardWrapper = styled.div<{ bgColor: string }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 13px;
+  width: 100%;
+  height: 220px;
+  padding: 24px 20px;
+  background-color: ${({ theme, bgColor }) => theme.diaryColor[bgColor].background};
+  border: 1px solid ${({ theme }) => theme.color.grayDF};
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+`;
+
+const DiaryDate = styled.div`
+  font-family: ${({ theme }) => theme.fontFamily.kor};
+  font-size: ${({ theme }) => theme.text.text3};
+`;
+
+const DiaryTitle = styled.div`
+  margin-bottom: 4px;
+  font-family: ${({ theme }) => theme.fontFamily.kor};
+  font-size: ${({ theme }) => theme.title.title4};
+  font-weight: 600;
+`;
+
+const DiaryTagBox = styled.div<{ bgColor: string }>`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 10px;
+
+  div {
+    font-size: ${({ theme }) => theme.text.text3};
+    color: ${({ theme }) => theme.color.gray};
+    background-color: ${({ theme, bgColor }) => theme.diaryColor[bgColor].tag};
+    padding: 4px 10px;
+    border-radius: 30px;
+  }
+`;
+
+const DiaryContent = styled.div`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  line-height: 24px;
+  font-family: ${({ theme }) => theme.fontFamily.kor};
+  font-size: ${({ theme }) => theme.text.text3};
+`;
+
+export default DiaryCard;

--- a/src/components/mypage/DiaryCard.tsx
+++ b/src/components/mypage/DiaryCard.tsx
@@ -49,6 +49,8 @@ const DiaryCard = ({
   );
 };
 
+export default DiaryCard;
+
 const DiaryCardWrapper = styled.div<{ bgColor: string }>`
   display: flex;
   flex-direction: column;
@@ -103,5 +105,3 @@ const DiaryContent = styled.div`
   font-family: ${({ theme }) => theme.fontFamily.kor};
   font-size: ${({ theme }) => theme.text.text3};
 `;
-
-export default DiaryCard;

--- a/src/hooks/useMyPage.ts
+++ b/src/hooks/useMyPage.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { fetchAllDiaries, fetchUserProfile } from "../api/mypage.api";
+import { IDiary } from "../models/diary.model";
+import { IUserProfile } from "../models/mypage.model";
+
+export const useMyPage = () => {
+  const [userProfile, setUserProfile] = useState<IUserProfile>();
+  const [userDiaries, setUserDiaries] = useState<IDiary[]>([]);
+
+  const storedUserId = localStorage.getItem('user_id');
+  const userId = storedUserId ? Number(storedUserId) : null;
+
+  const fetchUserProfileData = async (userId: number) => {
+    try {
+      const userProfileData = await fetchUserProfile(userId);
+      setUserProfile(userProfileData);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const fetchAllDiariesData = async () => {
+    try {
+      const userDiaryData = await fetchAllDiaries();
+      setUserDiaries(userDiaryData);
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  useEffect(() => {
+    fetchAllDiariesData();
+    fetchUserProfileData(userId!);
+  }, []);
+
+  return { userProfile, userDiaries };
+};

--- a/src/models/mypage.model.ts
+++ b/src/models/mypage.model.ts
@@ -1,0 +1,9 @@
+export interface IUserProfile {
+  id: number;
+  profile_img_url: string | null;
+  profile_background_img_url: string | null;
+  nickname: string;
+  email_address: string;
+  mate_count: number;
+  diary_count: number;
+}

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -7,6 +7,7 @@ import AllDiaries from '../components/mypage/AllDiaries';
 import MoodGraph from '../components/mypage/MoodGraph';
 import Playlist from '../components/mypage/Playlist';
 import Settings from '../components/mypage/Settings';
+import { useMyPage } from '../hooks/useMyPage';
 
 const MyPage = () => {
   const tabs = [
@@ -33,6 +34,7 @@ const MyPage = () => {
   ];
 
   const [selectedTab, setSelectedTab] = useState(tabs[0]);
+  const { userProfile } = useMyPage();
 
   return (
     <MyPageWrapper>
@@ -52,16 +54,16 @@ const MyPage = () => {
             <ProfileImg>
               <div className="image"></div>
             </ProfileImg>
-            <div className="nickname">meow</div>
-            <div className="email">meow@gmail.com</div>
+            <div className="nickname">{userProfile?.nickname}</div>
+            <div className="email">{userProfile?.email_address}</div>
             <div className="count">
               <div className="item mates">
                 <span className="name">친구</span>
-                <span className="num">5</span>
+                <span className="num">{userProfile?.mate_count}</span>
               </div>
               <div className="item diaries">
                 <span className="name">일기</span>
-                <span className="num">24</span>
+                <span className="num">{userProfile?.diary_count}</span>
               </div>
             </div>
           </InfoBox>
@@ -82,7 +84,7 @@ const MyPage = () => {
                   {tab.title === selectedTab.title && (
                     <FeedItemBackground
                       layoutId="feedActiveBackground"
-                      initial={false}
+                      initial={ false }
                       animate={{ opacity: 1 }}
                       exit={{ opacity: 0 }}
                       transition={{ duration: 0.15 }}
@@ -290,8 +292,9 @@ const FeedContent = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 20px 0;
+  /* padding: 20px 0; */
+  padding-top: 20px;
+  padding-bottom: 60px;
   width: 100%;
   height: 100%;
-  border: 1px solid blue;
 `;


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #58 
- 사용자 정보, 해당 사용자가 작성한 전체 일기를 조회하는 api를 연동하였습니다.

## ⭐ 작업 상세 설명

- localStorage에 저장된 user_id를 가져와 회원 정보를 얻어옴
```tsx
// 사용자 정보 조회 api
export const fetchUserProfile = async (userId: number) => {
  const response = await httpClient.get<IUserProfile>(`/api/users/${userId}`);
  return response.data;
};
```
- 사용자가 작성한 전체 일기가 배열 형태로 넘어오기 때문에, map 함수를 이용하여 각 요소마다 DiaryCard 컴포넌트에 출력될 수 있게 구현

![mypage-alldiaries](https://github.com/user-attachments/assets/9d9842fc-8577-4c12-9017-1265d6d6631c)


## 💬 리뷰 요구사항(선택)

- ex) 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
