### PR TITLE
[Feat] 마이페이지 환경설정 api 연동 #61

### DIFF
--- a/src/api/mypage.api.ts
+++ b/src/api/mypage.api.ts
@@ -5,7 +5,6 @@ import { IUserProfile } from "../models/mypage.model";
 // 사용자 정보 조회 api
 export const fetchUserProfile = async (userId: number) => {
   const response = await httpClient.get<IUserProfile>(`/api/users/${userId}`);
-  console.log(response.data);
 
   return response.data;
 };
@@ -13,6 +12,29 @@ export const fetchUserProfile = async (userId: number) => {
 // 전체 일기 조회 api
 export const fetchAllDiaries = async () => {
   const response = await httpClient.get<IDiary[]>("/api/diaries/myposts");
+
+  return response.data;
+};
+
+// 닉네임 중복 확인 api
+export const fetchCheckNickname = async (nickName: string) => {
+  const response = await httpClient.get(`/api/users/nicknames?nickname=${nickName}`);
+
+  return response.data;
+};
+
+// 닉네임 수정 api
+export const fetchChangeNickname = async (userId: number, nickName: string) => {
+  const response = await httpClient.put(`/api/users/${userId}/nickname`, {
+    nickname: nickName
+  });
+
+  return response.data;
+};
+
+// 회원 탈퇴 api
+export const fetchDeleteAccount = async (userId: number) => {
+  const response = await httpClient.delete(`/api/users/${userId}`);
 
   return response.data;
 };

--- a/src/components/mypage/DiaryCard.tsx
+++ b/src/components/mypage/DiaryCard.tsx
@@ -4,6 +4,23 @@ import { IDiary } from '../../models/diary.model';
 
 type DiaryCardProps = Pick<IDiary, 'id' | 'created_at' | 'body'>;
 
+export const handleFormatDate = (created_at: string) => {
+  const date = new Date(created_at);
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long',
+  };
+  return new Intl.DateTimeFormat('ko-KR', options).format(date);
+};
+
+const handleScriptHtml = (htmlContent: string) => {
+  const div = document.createElement("div.content");
+  div.innerHTML = htmlContent;
+  return div.innerText;
+};
+
 const DiaryCard = ({
   id,
   created_at,
@@ -15,22 +32,6 @@ const DiaryCard = ({
     navigate(`/diary/${id}`);
   };
 
-  const handleFormatDate = (created_at: string) => {
-    const date = new Date(created_at);
-    const options: Intl.DateTimeFormatOptions = {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      weekday: 'long',
-    };
-    return new Intl.DateTimeFormat('ko-KR', options).format(date);
-  };
-
-  const handleScriptHtml = (htmlContent: string) => {
-    const div = document.createElement("div.content");
-    div.innerHTML = htmlContent;
-    return div.innerText;
-  };
 
   return (
     <DiaryCardWrapper
@@ -56,7 +57,7 @@ const DiaryCardWrapper = styled.div<{ bgColor: string }>`
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
-  gap: 13px;
+  gap: 12px;
   width: 100%;
   height: 220px;
   padding: 24px 20px;

--- a/src/components/mypage/Settings.tsx
+++ b/src/components/mypage/Settings.tsx
@@ -1,13 +1,249 @@
 import styled from 'styled-components';
+import Button from '../button/Button';
+import { FiInfo } from "react-icons/fi";
+import { useState } from 'react';
+import { useMyPage } from '../../hooks/useMyPage';
+import { useAuth } from '../../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
 
 const Settings = () => {
+  const [nickname, setNickname] = useState<string>("");
+  const { 
+    isNicknameAvailable, 
+    hasCheckedNickname,
+    setHasCheckedNickname,
+    fetchCheckNicknameAvailability,
+    fetchChangeNicknameData,
+    fetchDeleteUserAccount,
+    deleteSuccess 
+  } = useMyPage();
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  const storedUserId = localStorage.getItem('user_id');
+  const userId = storedUserId ? Number(storedUserId) : null;
+  
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+    setHasCheckedNickname(false);
+  };
+
+  // 닉네임 중복확인 BTN
+  const handleClickCheckBtn = async () => {
+    await fetchCheckNicknameAvailability(nickname);
+    setHasCheckedNickname(true);
+  };
+
+  // 닉네임 변경 BTN
+  const handleClickChangeBtn = async () => {
+    if (!hasCheckedNickname) {
+      alert("닉네임 중복 확인을 먼저 해주세요.");
+      return;
+    }
+
+    if (isNicknameAvailable) {
+      await fetchChangeNicknameData(userId!, nickname);
+      alert("닉네임 변경이 완료되었습니다.");
+      window.location.reload();
+    } else {
+      alert("변경할 닉네임을 입력해주세요.");
+    }
+  };
+
+  // ghldn
+  const handleDeleteAccountBtn = () => {
+    if (window.confirm('정말 탈퇴하시겠습니까?')) {
+      const storedUserId = localStorage.getItem('user_id');
+      const userId = storedUserId ? Number(storedUserId) : null;
+      if (userId) {
+        fetchDeleteUserAccount(userId);
+        if (deleteSuccess) {
+          logout();
+          navigate("/");
+        }
+      }
+    }
+  };
+
   return (
     <SettingsWrapper>
-      <h1>Settings</h1>
+      <ChangeNickname>
+        <Title>닉네임 변경하기</Title>
+        <NicknameBox>
+          <NicknameInputBox>
+            <input
+              type="text"
+              value={nickname}
+              onChange={handleNicknameChange}
+            />
+            <Button
+              className='check-btn'
+              size={'short'}
+              schema={'gray'}
+              onClick={handleClickCheckBtn}
+            >중복확인</Button>
+          </NicknameInputBox>
+          {isNicknameAvailable === null && 
+            <span className='error-check'>2 ~ 14자로 입력해주세요.</span>
+          }
+          {isNicknameAvailable === true && 
+            <span className='error-check true'>사용 가능한 닉네임입니다.</span>
+          }
+          {isNicknameAvailable === false && 
+            <span className='error-check false'>이미 사용 중인 닉네임입니다.</span>
+          }
+          <Button
+            className='change-btn'
+            size="long" 
+            schema="white"
+            onClick={handleClickChangeBtn}
+          >변경하기</Button>
+        </NicknameBox>
+      </ChangeNickname>
+      <DeleteAccount>
+        <Title>회원탈퇴</Title>
+        <AccountBox>
+          <span
+            className='delete-btn'
+            onClick={handleDeleteAccountBtn}
+          >회원탈퇴</span>
+          <div className="delete-desc">
+            <FiInfo />
+            <span>모든 데이터가 삭제됩니다.</span>
+          </div>
+        </AccountBox>
+      </DeleteAccount>
     </SettingsWrapper>
   )
 };
 
-const SettingsWrapper = styled.div``;
-
 export default Settings;
+
+const SettingsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 564px;
+`;
+
+const ChangeNickname = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 16px;
+  width: 100%;
+`;
+
+const Title = styled.h1`
+  font-family: ${({ theme }) => theme.fontFamily.kor};
+  font-size: ${({ theme }) => theme.title.title3};
+  font-weight: 600;
+`;
+
+const NicknameBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 6px;
+  width: 100%;
+
+  .change-btn {
+    padding: 8px 150px;
+    border-radius: 8px;
+    font-weight: 600;
+    
+    &:hover {
+      color: ${({ theme }) => theme.color.white};
+      background-color: ${({ theme }) => theme.color.primary};
+    }
+  }
+  
+  .error-check {
+    margin-left: 4px;
+    margin-bottom: 6px;
+    color: ${({ theme }) => theme.color.gray777};
+    font-family: ${({ theme }) => theme.fontFamily.kor};
+    font-size: ${({ theme }) => theme.text.text2};
+
+    &.true {
+      color: ${({ theme }) => theme.color.primary};
+    }
+
+    &.false {
+      color: red;
+    }
+  }
+`;
+
+const NicknameInputBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+
+  input {
+    width: 357px;
+    padding: 8px 10px;
+    color: ${({ theme }) => theme.color.black};
+    border-radius: 6px;
+    border: 1px solid ${({ theme }) => theme.color.grayDF};
+    outline: none;
+
+    &:focus {
+      border: 1px solid ${({ theme }) => theme.color.primary};
+    }
+  }
+
+  .check-btn {
+    padding: 10px 18px;
+
+    &:hover {
+      background-color: ${({ theme }) => theme.color.grayDF};
+    }
+  }
+`;
+
+const DeleteAccount = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 16px;
+  width: 100%;
+`;
+
+const AccountBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+  color: ${({ theme }) => theme.color.gray777};
+
+  .delete-btn {
+    font-size: ${({ theme }) => theme.text.text2};
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .delete-desc {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 4px;
+
+    svg {
+      font-size: 14px;
+    }
+
+    span {
+      font-size: ${({ theme }) => theme.text.text2};
+    }
+  }
+`;

--- a/src/hooks/useMyPage.ts
+++ b/src/hooks/useMyPage.ts
@@ -1,15 +1,22 @@
 import { useEffect, useState } from "react";
-import { fetchAllDiaries, fetchUserProfile } from "../api/mypage.api";
+import { fetchAllDiaries, fetchUserProfile, fetchCheckNickname, fetchChangeNickname, fetchDeleteAccount } from "../api/mypage.api";
 import { IDiary } from "../models/diary.model";
 import { IUserProfile } from "../models/mypage.model";
+import { useNavigate } from "react-router-dom";
 
 export const useMyPage = () => {
   const [userProfile, setUserProfile] = useState<IUserProfile>();
   const [userDiaries, setUserDiaries] = useState<IDiary[]>([]);
+  const [isNicknameAvailable, setIsNicknameAvailable] = useState<boolean | null>(null);
+  const [hasCheckedNickname, setHasCheckedNickname] = useState<boolean>(false); 
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteSuccess, setDeleteSuccess] = useState<boolean | null>(null);
 
+  const navigate = useNavigate();
   const storedUserId = localStorage.getItem('user_id');
   const userId = storedUserId ? Number(storedUserId) : null;
 
+  // 사용자 정보 조회
   const fetchUserProfileData = async (userId: number) => {
     try {
       const userProfileData = await fetchUserProfile(userId);
@@ -19,6 +26,7 @@ export const useMyPage = () => {
     }
   };
 
+  // 사용자가 작성한 전체 일기 조회
   const fetchAllDiariesData = async () => {
     try {
       const userDiaryData = await fetchAllDiaries();
@@ -26,12 +34,68 @@ export const useMyPage = () => {
     } catch (err) {
       console.log(err);
     }
-  }
+  };
+
+  // 닉네임 중복 확인
+  const fetchCheckNicknameAvailability = async (nickname: string) => {
+    try {
+      await fetchCheckNickname(nickname);
+      setIsNicknameAvailable(true);  // 200 응답의 경우 사용 가능
+    } catch (err: any) {
+      if (err.response?.status === 409) {
+        setIsNicknameAvailable(false); // 409 응답의 경우 사용 불가
+      } else {
+        console.log(err);
+        setIsNicknameAvailable(null); 
+      }
+    }
+  };
+  
+  // 닉네임 변경
+  const fetchChangeNicknameData = async (userId: number, nickname: string) => {
+    if (userId === null) return;
+
+    try {
+      await fetchChangeNickname(userId, nickname);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  // 회원 탈퇴
+  const fetchDeleteUserAccount = async (userId: number) => {
+    try {
+      setIsDeleting(true);
+      await fetchDeleteAccount(userId);
+      setDeleteSuccess(true);
+      localStorage.removeItem('access_token');
+      localStorage.removeItem('user_id');
+      navigate("/");
+    } catch (err) {
+      setDeleteSuccess(false);
+      console.log(err);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
   useEffect(() => {
-    fetchAllDiariesData();
-    fetchUserProfileData(userId!);
-  }, []);
+    if (userId !== null) {
+      fetchAllDiariesData();
+      fetchUserProfileData(userId);
+    }
+  }, [userId]);
 
-  return { userProfile, userDiaries };
+  return { 
+    userProfile, 
+    userDiaries, 
+    isNicknameAvailable, 
+    hasCheckedNickname,
+    setHasCheckedNickname,
+    fetchCheckNicknameAvailability,
+    fetchChangeNicknameData,
+    fetchDeleteUserAccount,
+    isDeleting,
+    deleteSuccess
+  };
 };

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -56,7 +56,7 @@ export interface Theme {
     [key in ButtonSize]: {
       padding: string;
       fontSize: string;
-      fontWeight: string;
+      fontWeight: number;
       borderRadius: string;
     };
   };
@@ -154,20 +154,20 @@ export const theme: Theme = {
     short: {
       padding: "7px 13px",
       fontSize: "12px",
-      fontWeight: "regular",
+      fontWeight: 400,
       borderRadius: "6px",
     },
     medium: {
       padding: "8px 17px",
       fontSize: "14px",
-      fontWeight: "regular",
-      borderRadius: "10px",
+      fontWeight: 400,
+      borderRadius: "8px",
     },
     long: {
       padding: "13px 150px",
       fontSize: "16px",
-      fontWeight: "bold",
-      borderRadius: "14px",
+      fontWeight: 600,
+      borderRadius: "12px",
     },
   },
   buttonSchema: {


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #61 
- 마이페이지 - 환경설정 컴포넌트 UI 구현 및 닉네임 중복확인, 변경, 회원탈퇴 api 연동하였습니다.

## ⭐ 작업 상세 설명

- [GET] /api/users/nicknames : 닉네임 중복 확인
  - `중복확인` 버튼 클릭 시 사용 가능한 닉네임인지 아닌지 구별할 수 있음
  - input란이 바뀌면 다시 중복확인을 꼭 거쳐야 함
- [PUT] /api/users/{userId}/nickname : 닉네임 변경
  - `변경하기` 버튼 클릭 시 변경이 가능하며, 중복확인을 거치지 않은 경우 "닉네임 중복 확인을먼저 해주세요." 라는 알림창이 나옴
  - 변경이 완료되면 창이 reload됨

![mypage-changeNickname](https://github.com/user-attachments/assets/d74e9b26-8600-43fc-8d5c-6c70b76fe67f)

- [DELETE] /api/users/{userId} : 회원 탈퇴
  - localStorage에 있는 user_id와 access_token 삭제 및 로그아웃 상태가 됨
  (현재 로컬 서버에서 구현하고 있어 로그아웃 돼도 첫 화면으로 돌아가지 않는...!!!)

![mypage-deleteAccount](https://github.com/user-attachments/assets/712dbda0-a306-42f5-b6d0-7de07fdcdac1)

## 💬 리뷰 요구사항(선택)

- 프로필 사진, 배경 사진 업로드는 미구현 상태입니다! 쥬르륵~
