### PR TITLE
[Feat] 일기작성페이지 s3 이미지 api 연동 및 수정 #78

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4",
         "zustand": "^4.5.4"
+      },
+      "devDependencies": {
+        "@types/uuid": "^10.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4306,6 +4309,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.11",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/uuid": "^10.0.0"
   }
 }

--- a/src/api/diary.api.ts
+++ b/src/api/diary.api.ts
@@ -45,4 +45,24 @@ export const fetchDeleteDiary = async (diaryId: number) => {
   }
 };
 
+// 이미지 파일 추가
+export const fetchUploadDiaryImage = async (images: { file: File; filename: string }[]) => {
+  const formData = new FormData();
+  images.forEach(image => {
+    formData.append('files', image.file); // 이미지 파일 추가
+    formData.append('filenames', image.filename); // 이미지 파일명 추가
+  });
 
+  try {
+    const response = await httpClient.post('/api/aws/images', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    
+    return response.data.image_urls;
+  } catch (error) {
+    console.error('Error uploading images', error);
+    throw error; // 오류 발생 시 호출한 쪽에서 처리할 수 있도록 예외를 던집니다.
+  }
+};

--- a/src/components/diary/DiaryEditor.tsx
+++ b/src/components/diary/DiaryEditor.tsx
@@ -1,37 +1,36 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
+import { formats, modules } from '../../constants/writeDiary';
+import { fetchUploadDiaryImage } from '../../api/diary.api';
+import { useDiaries } from '../../hooks/useDiary';
 
-const modules = {
-  toolbar: [
-    [{ 'font': [] }, { 'size': [] }],
-    ['bold', 'italic', 'underline', 'strike'],
-    [{ 'color': [] }, { 'background': [] }],
-    [{ 'header': '1' }, { 'header': '2' }, 'blockquote', 'code-block'],
-    [{ 'list': 'ordered' }, { 'list': 'bullet' }],
-    [{ 'align': [] }],
-    ['link', 'image']
-  ]
-};
+interface DiaryEditorProps {
+  content: string;
+  onChange: (value: string) => void;
+}
 
-const formats = [
-  'font', 'size', 'bold', 'italic', 'underline', 'strike', 'color', 'background', 'header', 'blockquote', 'code-block', 'list', 'bullet',
-  'align', 'link', 'image'
-];
 
-const DiaryEditor = ({ content, onChange }: { 
-  content: string, 
-  onChange: (value: string) => void 
-}) => {
+const DiaryEditor = ({ content, onChange }: DiaryEditorProps) => {
+  const quillRef = useRef<ReactQuill | null>(null);
+
   return (
     <DiaryEditorWrapper>
       <ReactQuill
+        ref={quillRef}
         value={content} 
-        onChange={onChange} 
-        modules={modules} 
-        formats={formats} 
+        onChange={onChange}
+        formats={formats}
+        modules={modules}
       />
+      {/* <input 
+        ref={contentRef}
+        type='file'
+        style={{ display: 'none' }}
+        accept='image/*'
+        // onChange={(e) => }
+      /> */}
     </DiaryEditorWrapper>
   );
 };
@@ -46,3 +45,100 @@ const DiaryEditorWrapper = styled.div`
     height: 600px;
   }
 `;
+
+
+// import styled from 'styled-components';
+// import { useRef, useState } from 'react';
+// import ReactQuill from 'react-quill';
+// import 'react-quill/dist/quill.snow.css';
+// import { formats, modules as defaultModules } from '../../constants/writeDiary';
+// import { fetchUploadDiaryImage } from '../../api/diary.api';
+// import { v4 as uuidv4 } from 'uuid';
+
+// interface DiaryEditorProps {
+//   content: string;
+//   onChange: (value: string) => void;
+//   userId: number;
+// }
+
+// const DiaryEditor = ({ content, onChange, userId }: DiaryEditorProps) => {
+//   const quillRef = useRef<ReactQuill | null>(null);
+//   const fileInputRef = useRef<HTMLInputElement>(null);
+//   const [imageOrder, setImageOrder] = useState(0); // 이미지 순서를 관리하는 state
+
+//   const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+//     const file = event.target.files?.[0];
+//     if (file) {
+//       try {
+//         // 임시 파일명 생성
+//         const tempFilename = `${userId}/diary/temp_${uuidv4()}_${imageOrder}.png`;
+
+//         // 이미지 업로드 로직 (서버 API로 전송 후 URL을 받음)
+//         const imageDetails = [{ file, filename: tempFilename }];
+//         const [imageUrl] = await fetchUploadDiaryImage(imageDetails);
+
+//         // Quill에 이미지 삽입
+//         const quill = quillRef.current?.getEditor();
+//         const range = quill?.getSelection();
+//         if (range && quill) {
+//           quill.insertEmbed(range.index, 'image', imageUrl);
+//           // range.index가 undefined일 경우를 처리하기 위해 기본값을 설정
+//           const newIndex = range.index !== undefined ? range.index + 1 : quill.getLength();
+//           // quill.setSelection(newIndex);
+//         }
+
+//         // 이미지 순서 증가
+//         setImageOrder(prevOrder => prevOrder + 1);
+
+//       } catch (error) {
+//         console.error('Error uploading image:', error);
+//       }
+//     }
+//   };
+
+//   const imageHandler = () => {
+//     if (fileInputRef.current) {
+//       fileInputRef.current.click();
+//     }
+//   };
+
+//   const modules = {
+//     ...defaultModules,
+//     toolbar: {
+//       ...defaultModules.toolbar,
+//       handlers: {
+//         image: imageHandler,
+//       },
+//     },
+//   };
+
+//   return (
+//     <DiaryEditorWrapper>
+//       <ReactQuill
+//         ref={quillRef}
+//         value={content}
+//         onChange={onChange}
+//         formats={formats}
+//         modules={modules}
+//       />
+//       <input
+//         ref={fileInputRef}
+//         type="file"
+//         style={{ display: 'none' }}
+//         accept="image/*"
+//         onChange={handleImageUpload}
+//       />
+//     </DiaryEditorWrapper>
+//   );
+// };
+
+// export default DiaryEditor;
+
+// const DiaryEditorWrapper = styled.div`
+//   width: 100%;
+
+//   .ql-container {
+//     width: 100%;
+//     height: 600px;
+//   }
+// `;

--- a/src/components/diary/DiaryPreview.tsx
+++ b/src/components/diary/DiaryPreview.tsx
@@ -2,6 +2,9 @@ import styled from "styled-components";
 import DiaryContent from "./DiaryContent";
 import profile from "../../assets/images/mypage/mypage-bg.jpg";
 import MusicBar from "../musicbar/MusicBar";
+import { useMyPage } from "../../hooks/useMyPage";
+import { IDiary } from "../../models/diary.model";
+import { getPrivacyIcon } from "../../pages/WriteDiary";
 
 interface Props {
   title: string;
@@ -36,54 +39,57 @@ const DiaryPreview = ({
   avgTemperature,
   imgUrls,
 }: Props) => {
-  const diary = {
+  const { userProfile } = useMyPage();
+
+  // DiaryContent에서 요구하는 구조를 따른 diary 객체 생성
+  const diary: IDiary = {
     id: 1, // 임의로 설정
-    user_id: "damii",
+    user_profile: {
+      user_id: userProfile?.id!, 
+      nickname: userProfile?.nickname!, 
+      profile_img_url: userProfile?.profile_img_url!, 
+    },
     like_count: 0,
-    created_at: formattedDate,
+    created_at: formattedDate || null,
     body: {
-      title,
-      content,
-      img_urls: imgUrls,
-      mood: selectedMood,
-      emoji: selectedEmoji,
-      privacy: selectedPrivacy,
+      title: title || "", // title이 없을 때 빈 문자열을 기본값으로 설정
+      content: content || "", // content가 없을 때 빈 문자열을 기본값으로 설정
+      img_urls: imgUrls || null, // imgUrls이 없을 때 null로 설정
+      mood: selectedMood || null,
+      emoji: selectedEmoji || null,
+      privacy: selectedPrivacy === "private" || selectedPrivacy === "public" || selectedPrivacy === "mate" ? selectedPrivacy : "private",
       music: {
         title: musicTitle,
         artist: musicArtist,
-        music_url: musicUrl,
+        music_url: musicUrl
       },
       weather: {
+        location: location,
         icon: weatherIcon,
-        location,
-        avg_temperature: avgTemperature,
+        avg_temperature: Number(avgTemperature),
       },
-      background_color: selectedBgColor,
+      background_color: selectedBgColor || null,
     },
+    liked: false
   };
 
   return (
     <DiaryPreviewWrapper>
       <DiaryPreviewContents bgColor={selectedBgColor}>
+        <Privacy>{getPrivacyIcon(selectedPrivacy)}</Privacy>
         <Header>
           <div className="date">{formattedDate}</div>
           <ProfileWrapper>
             <div className="profile"></div>
-            <span>damii</span>
+            <span>{userProfile?.nickname}</span> {/* 실제 사용자 이름으로 변경 */}
           </ProfileWrapper>
         </Header>
         <Title>{title}</Title>
-        {/* <DiaryContent
+        <DiaryContent
           diary={diary} 
           isSummary={false} 
-          isExpanded={true} 
-          user={{
-            user_id: 0,
-            profileImgURL: null,
-            nickname: ""
-          }} 
-          likedUsers={[]} 
-        /> */}
+          isExpanded={true}
+        />
         <MusicBar
           isExpanded={true}
           title={musicTitle}
@@ -118,18 +124,31 @@ const DiaryPreviewContents = styled.div<{ bgColor: string }>`
   flex-direction: column;
   width: 80%;
   height: 90%;
-  padding: 60px 0;
+  padding: 80px 0;
   background-color: ${({ theme, bgColor }) =>
     theme.diaryColor[bgColor].background};
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
 `;
 
+const Privacy = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+  padding: 0 10%;
+  color: ${({ theme }) => theme.color.gray999};
+  font-size: ${({ theme }) => theme.text.text3};
+  cursor: pointer;
+`;
+
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
   padding: 0 10%;
 
   .date {

--- a/src/components/mypage/AllDiaries.tsx
+++ b/src/components/mypage/AllDiaries.tsx
@@ -6,7 +6,7 @@ const AllDiaries = () => {
   const { userDiaries } = useMyPage();
 
   if (!userDiaries || userDiaries.length === 0) {
-    return <div>Loading...</div>;
+    return <NoDiaries>작성된 일기가 없습니다.</NoDiaries>;
   }
 
   return (
@@ -26,6 +26,11 @@ const AllDiaries = () => {
 };
 
 export default AllDiaries;
+
+const NoDiaries = styled.div`
+  color: ${({ theme }) => theme.color.gray777};
+  height: calc(100vh - 524px);
+`;
 
 const AllDiariesWrapper = styled.div`
   width: 1014px;

--- a/src/constants/writeDiary.ts
+++ b/src/constants/writeDiary.ts
@@ -17,3 +17,20 @@ export const colors = [
 export const moods = ["😍", "😆", "🙂", "😟", "😡"];
 
 export const privacies = ["public", "mate", "private"];
+
+export const modules = {
+  toolbar: [
+    [{ 'font': [] }, { 'size': [] }],
+    ['bold', 'italic', 'underline', 'strike'],
+    [{ 'color': [] }, { 'background': [] }],
+    [{ 'header': '1' }, { 'header': '2' }, 'blockquote', 'code-block'],
+    [{ 'list': 'ordered' }, { 'list': 'bullet' }],
+    [{ 'align': [] }],
+    ['link', 'image']
+  ]
+};
+
+export const formats = [
+  'font', 'size', 'bold', 'italic', 'underline', 'strike', 'color', 'background', 'header', 'blockquote', 'code-block', 'list', 'bullet',
+  'align', 'link', 'image'
+];

--- a/src/pages/WriteDiary.tsx
+++ b/src/pages/WriteDiary.tsx
@@ -37,7 +37,6 @@ const WriteDiary = () => {
   const routerLocation = useLocation();
   const diaryToEdit = routerLocation.state?.diary;
   const navigate = useNavigate();
-  const user_id = localStorage.getItem("user_id");
 
   // 상태 변수 선언
   const [title, setTitle] = useState<string>("");
@@ -106,13 +105,44 @@ const WriteDiary = () => {
       background_color: selectedBgColor || "default",
     };
 
+    const youtubeUrlPattern = /^(https?:\/\/)?(www\.youtube\.com|youtu\.?be)\/.+$/;
+
+    if (!diaryData.title) {
+      window.alert("제목을 입력해주세요.");
+      return;
+    } 
+    if (!diaryData.music?.title) {
+      window.alert("음악 제목을 입력해주세요.");
+      return;
+    } 
+    if (!diaryData.music?.artist) {
+      window.alert("아티스트를 입력해주세요.");
+      return;
+    } 
+    if (!diaryData.music?.music_url) {
+      window.alert("음악 유튜브 링크를 입력해주세요.");
+      return;
+    } 
+    if (!youtubeUrlPattern.test(diaryData.music.music_url)) {
+      window.alert("올바른 유튜브 링크를 입력해주세요.");
+      return;
+    }
+    if (!diaryData.emoji) {
+      window.alert("오늘의 이모지를 선택해주세요.");
+      return;
+    } 
+    if (!diaryData.content) {
+      window.alert("일기 내용을 작성해주세요.");
+      return;
+    }
+
     // 모든 필드가 작성되었는지 확인하는 함수
-    const isDiaryDataValid = Object.values(diaryData).every((value) => {
-      if (typeof value === 'object' && value !== null) {
-        return Object.values(value).every((v) => v !== "" && v !== null && v !== undefined);
-      }
-      return value !== "" && value !== null && value !== undefined;
-    });
+    // const isDiaryDataValid = Object.values(diaryData).every((value) => {
+    //   if (typeof value === 'object' && value !== null) {
+    //     return Object.values(value).every((v) => v !== "" && v !== null && v !== undefined);
+    //   }
+    //   return value !== "" && value !== null && value !== undefined;
+    // });
 
     try {
       if (diaryToEdit) {
@@ -120,13 +150,13 @@ const WriteDiary = () => {
         await updateDiary(diaryToEdit.id, diaryData);
       } else {
         // 다이어리 저장의 경우
-        if (isDiaryDataValid) {
-          await saveDiary(diaryData);
-          window.alert("일기가 저장되었습니다.");
-          navigate("/home");
-        } else {
-          window.alert("모든 항목을 작성해주세요.");
-        }
+        await saveDiary(diaryData);
+        window.alert("일기가 저장되었습니다.");
+        navigate("/home");
+        // if (isDiaryDataValid) {
+        // } else {
+        //   window.alert("모든 항목을 작성해주세요.");
+        // }
       }
     } catch (error) {
       console.error("일기 저장 중 오류 발생:", error);
@@ -153,8 +183,7 @@ const WriteDiary = () => {
   const { location, error } = useGeoLocation(geolocationOptions);
   let lat = location?.latitude;
   let long = location?.longitude;
-  // console.log("위도 : ", lat);
-  // console.log("경도 : ", long);
+
   const access_token = localStorage.getItem("access_token");
   useEffect(() => {
     //수정일 경우 호출 X
@@ -328,7 +357,7 @@ const WriteDiary = () => {
           <div className="icon" ref={emojiDropdownRef}>
             <div onClick={toogleEmojiDropdown}>
               <FiPlusCircle />
-              <span>아이콘 추가</span>
+              <span>이모지 추가</span>
             </div>
             {isEmojiDropdown && (
               <div className="emoji-picker">
@@ -454,7 +483,11 @@ const WriteDiary = () => {
           </div>
         </Section>
         {/* 일기 작성 에디터 */}
-        <DiaryEditor content={content} onChange={setContent} />
+        <DiaryEditor
+          content={content} 
+          onChange={setContent} 
+          // userId={Number(userId)} 
+        />
         {/* 미리보기, 등록하기 BTN */}
         <SubmitBox ref={previewOpenRef}>
           <Button
@@ -480,6 +513,8 @@ const WriteDiary = () => {
     </WriteDiaryWrapper>
   );
 };
+
+export default WriteDiary;
 
 const WriteDiaryWrapper = styled.div<{ bgColor: string }>`
   display: flex;
@@ -754,5 +789,3 @@ const SubmitBox = styled.div`
   align-items: center;
   gap: 12px;
 `;
-
-export default WriteDiary;


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #78 
- S3에 이미지 저장 (미구현)
- 일기 작성 미리보기 수정
- 일기 작성 페이지 에디터 모듈 및 툴 분리
- 일기 작성 페이지 값 미입력 시 상황에 맞는 알림창 구현
- 마이페이지 전체 일기 조회 로딩 style 수정

## ⭐ 작업 상세 설명

- 마이페이지 전체 일기 조회 로딩 style 수정
![스크린샷 2024-08-27 오후 5 32 45](https://github.com/user-attachments/assets/f9d9b258-b02d-4309-808f-8dfe74899cac)

- 일기 작성 페이지 값 미입력 시 상황에 맞는 알림창 구현
![스크린샷 2024-08-27 오후 5 33 13](https://github.com/user-attachments/assets/20d5dadf-b184-4160-89e7-811daa567066)

## 💬 리뷰 요구사항(선택)

- 추후 수정할 부분
  - dlary 모델 타입 수정 (null값도 포함하여 그에 맞게 모든 파일 변경 필요)
  - 일기 작성 에디터에서 S3 이미지 저장
